### PR TITLE
Added raw emitting for utf16 where it fails to decode the event

### DIFF
--- a/pypyodbc.py
+++ b/pypyodbc.py
@@ -494,13 +494,21 @@ def UTF16_dec(buffer):
         if is_null_byte_pair:
             found_null = True
             break
-
     if found_null:
         # We now decode all the characters in the actual data,
         # without the garbage
-        ret = buffer.raw[:i - 1].decode(odbc_decoding)
+        to_decode = buffer.raw[:i - 1]
     else:
-        ret = buffer.raw.decode(odbc_decoding)
+        to_decode = buffer.raw
+
+    try:
+        ret = to_decode.decode(odbc_decoding)
+    except UnicodeDecodeError:
+        # We print as there is no logging here
+        print 'pypyodbc failed to decode "%s". Emitting in '
+              'raw form' % to_decode
+        ret = to_decode
+
     return ret
 
 from_buffer_u = lambda buffer: buffer.value


### PR DESCRIPTION
This PR allows pypyodbc to emit a raw bytes string if it fails to decode it, so we catch it later in our code and detect the encoding as we do for other inputs. @ramiamar @oxmane DYT I should add it as a parameter to the connection? I don't think we plan on opening a PR to the main repo, so maybe there is no need (we'll use it with this feature anyway)