### PR TITLE
Added handling for when a decimal string has a postfixed \x00 character

### DIFF
--- a/pypyodbc.py
+++ b/pypyodbc.py
@@ -612,7 +612,10 @@ def dt_cvt(x):
 def Decimal_cvt(x):
     if py_v3:
         x = x.decode('ascii')
-    return Decimal(x)
+    try:
+        return Decimal(x)
+    except Exception:
+        return Decimal(x.rstrip('\x00'))
 
 bytearray_cvt = bytearray
 if sys.platform == 'cli':


### PR DESCRIPTION
This is a fix for the grailed bug, when sometimes pypyodbc returns a null byte at the end of a decimal string