### PR TITLE
Don't convert empty strings to None

### DIFF
--- a/pypyodbc.py
+++ b/pypyodbc.py
@@ -1893,12 +1893,6 @@ class Cursor:
                                     value_list.append(buf_cvt_func(alloc_buffer.raw[:used_buf_len.value]))
                                 elif target_type == SQL_C_WCHAR:
                                     value_list.append(buf_cvt_func(from_buffer_u(alloc_buffer)))
-                                # Bit column type return \x00\x00 for 0,
-                                # but alloc_buffer.value = '' in this case
-                                # so we return None instead of 0
-                                elif alloc_buffer.value == '' and not \
-                                                alloc_buffer.raw == '\x00\x00':
-                                    value_list.append(None)
                                 else:
                                     # line below fails when chr(0) in result, hence replaced with the active line below
                                     #value_list.append(buf_cvt_func(alloc_buffer.value))


### PR DESCRIPTION
PypyOdbc added it for compatibility with Firebase (https://github.com/jiangwen365/pypyodbc/pull/6/files)
Let's remember that we might need this back when we start supporting Firebase.