### PR TITLE
UTF16 Decode String Fix

### DIFF
--- a/pypyodbc.py
+++ b/pypyodbc.py
@@ -492,7 +492,7 @@ def UCS_dec(buffer):
 
 def UTF16_dec(buffer):
     raw = buffer.raw
-    print("Raw Buffer: %b" % raw)
+    print("Raw Buffer: %s" % raw)
 
     if raw.startswith("\x00\x00"):
         return ""
@@ -521,7 +521,7 @@ def UTF16_dec(buffer):
 
     if 'MarshallPlan' in to_decode.decode(odbc_decoding):
         import ipdb; ipdb.set_trace()
-        
+
     try:
         ret = to_decode.decode(odbc_decoding)
     except UnicodeDecodeError:

--- a/pypyodbc.py
+++ b/pypyodbc.py
@@ -492,6 +492,7 @@ def UCS_dec(buffer):
 
 def UTF16_dec(buffer):
     raw = buffer.raw
+    print("Raw Buffer: %s" % raw)
     if raw.startswith("\x00\x00"):
         return ""
     last_match = raw.find("\x00\x00\x00")

--- a/pypyodbc.py
+++ b/pypyodbc.py
@@ -502,23 +502,23 @@ def UTF16_dec(buffer):
     if last_match != -1:
         if last_match % 2 == 0:
             to_decode = raw[:last_match]
-	    if debug_flag:
-		    print("KOOOOOKKOOO")
+        if debug_flag:
+            print("KOOOOOKKOOO")
 
         else:
-	        if debug_flag:
-		        print("Boo")
+            if debug_flag:
+                print("Boo")
             to_decode = raw[:last_match + 1]
 
     elif "\x00" == raw[l - 1] and "\x00" == raw[l - 2]:
         if debug_flag:
-		    print("YOYOYO")
-	    to_decode = raw[:l - 2]
+            print("YOYOYO")
+        to_decode = raw[:l - 2]
 
     else:
         if debug_flag:
-		    print("SHANI IS RIGHT")
-	to_decode = raw
+            print("SHANI IS RIGHT")
+    to_decode = raw
 
     try:
         ret = to_decode.decode(odbc_decoding)

--- a/pypyodbc.py
+++ b/pypyodbc.py
@@ -493,7 +493,7 @@ def UCS_dec(buffer):
 def UTF16_dec(buffer):
     raw = buffer.raw
     print("Raw Buffer: %s" % raw)
-    debug_flag = 'MarshallPlan' in raw
+    debug_flag = 'driver debt settled' in raw
     print("Debug flag is %s" % debug_flag)
 
     if raw.startswith("\x00\x00"):

--- a/pypyodbc.py
+++ b/pypyodbc.py
@@ -493,6 +493,8 @@ def UCS_dec(buffer):
 def UTF16_dec(buffer):
     raw = buffer.raw
     print("Raw Buffer: %s" % raw)
+    debug_flag = 'MarshallPlan' in raw
+
     if raw.startswith("\x00\x00"):
         return ""
     last_match = raw.find("\x00\x00\x00")
@@ -500,15 +502,23 @@ def UTF16_dec(buffer):
     if last_match != -1:
         if last_match % 2 == 0:
             to_decode = raw[:last_match]
+	    if debug_flag:
+		print("KOOOOOKKOOO")
 
         else:
+	    if debug_flag:
+		print("Boo")
             to_decode = raw[:last_match + 1]
 
     elif "\x00" == raw[l - 1] and "\x00" == raw[l - 2]:
-        to_decode = raw[:l - 2]
+        if debug_flag:
+		print("YOYOYO")
+	to_decode = raw[:l - 2]
 
     else:
-        to_decode = raw
+        if debug_flag:
+		print("SHANI IS RIGHT")
+	to_decode = raw
 
     try:
         ret = to_decode.decode(odbc_decoding)

--- a/pypyodbc.py
+++ b/pypyodbc.py
@@ -492,7 +492,7 @@ def UCS_dec(buffer):
 
 def UTF16_dec(buffer):
     raw = buffer.raw
-    print("Raw Buffer: %s" % raw)
+    print("Raw Buffer: %b" % raw)
 
     if raw.startswith("\x00\x00"):
         return ""
@@ -519,6 +519,9 @@ def UTF16_dec(buffer):
     else:
         to_decode = raw
 
+    if 'MarshallPlan' in to_decode:
+        import ipdb; ipdb.set_trace()
+        
     try:
         ret = to_decode.decode(odbc_decoding)
     except UnicodeDecodeError:

--- a/pypyodbc.py
+++ b/pypyodbc.py
@@ -506,11 +506,11 @@ def UTF16_dec(buffer):
 
     l = len(raw)
     if last_match != -1:
-        if last_match % 2 == 0:
-            to_decode = raw[:last_match]
+        #if last_match % 2 == 0:
+        to_decode = raw[:last_match]
 
-        else:
-            to_decode = raw[:last_match + 1]
+    #    else:
+    #        to_decode = raw[:last_match + 1]
 
     elif "\x00" == raw[l - 1] and "\x00" == raw[l - 2]:
         to_decode = raw[:l - 2]

--- a/pypyodbc.py
+++ b/pypyodbc.py
@@ -494,9 +494,8 @@ def UTF16_dec(buffer):
     raw = buffer.raw
     print("Raw Buffer: %s" % raw)
     debug_flag = 'MarshallPlan' in raw
-    if debug_flag:
-        import ipdb; ipdb.set_trace()
-        
+    print("Debug flag is %s" % debug_flag)
+
     if raw.startswith("\x00\x00"):
         return ""
     last_match = raw.find("\x00\x00\x00")

--- a/pypyodbc.py
+++ b/pypyodbc.py
@@ -494,7 +494,9 @@ def UTF16_dec(buffer):
     raw = buffer.raw
     print("Raw Buffer: %s" % raw)
     debug_flag = 'MarshallPlan' in raw
-
+    if debug_flag:
+        import ipdb; ipdb.set_trace()
+        
     if raw.startswith("\x00\x00"):
         return ""
     last_match = raw.find("\x00\x00\x00")

--- a/pypyodbc.py
+++ b/pypyodbc.py
@@ -503,21 +503,21 @@ def UTF16_dec(buffer):
         if last_match % 2 == 0:
             to_decode = raw[:last_match]
 	    if debug_flag:
-		print("KOOOOOKKOOO")
+		    print("KOOOOOKKOOO")
 
         else:
-	    if debug_flag:
-		print("Boo")
+	        if debug_flag:
+		        print("Boo")
             to_decode = raw[:last_match + 1]
 
     elif "\x00" == raw[l - 1] and "\x00" == raw[l - 2]:
         if debug_flag:
-		print("YOYOYO")
-	to_decode = raw[:l - 2]
+		    print("YOYOYO")
+	    to_decode = raw[:l - 2]
 
     else:
         if debug_flag:
-		print("SHANI IS RIGHT")
+		    print("SHANI IS RIGHT")
 	to_decode = raw
 
     try:

--- a/pypyodbc.py
+++ b/pypyodbc.py
@@ -497,9 +497,9 @@ def UTF16_dec(buffer):
     if raw.startswith("\x00\x00"):
         return ""
     
-    last_match = raw.find("\x00\x00")
-    while last_match != -1 and last_match % 2 != 0:
-        last_match = raw.find("\x00\x00", last_match + 2)
+    last_match = raw.find("\x00\x00\x00")
+    #while last_match != -1 and last_match % 2 != 0:
+    #    last_match = raw.find("\x00\x00", last_match + 2)
         
     l = len(raw)
     if last_match != -1:

--- a/pypyodbc.py
+++ b/pypyodbc.py
@@ -493,8 +493,6 @@ def UCS_dec(buffer):
 def UTF16_dec(buffer):
     raw = buffer.raw
     print("Raw Buffer: %s" % raw)
-    debug_flag = 'driver debt settled' in raw
-    print("Debug flag is %s" % debug_flag)
 
     if raw.startswith("\x00\x00"):
         return ""
@@ -503,22 +501,14 @@ def UTF16_dec(buffer):
     if last_match != -1:
         if last_match % 2 == 0:
             to_decode = raw[:last_match]
-        if debug_flag:
-            print("KOOOOOKKOOO")
 
         else:
-            if debug_flag:
-                print("Boo")
             to_decode = raw[:last_match + 1]
 
     elif "\x00" == raw[l - 1] and "\x00" == raw[l - 2]:
-        if debug_flag:
-            print("YOYOYO")
         to_decode = raw[:l - 2]
 
     else:
-        if debug_flag:
-            print("SHANI IS RIGHT")
         to_decode = raw
 
     try:

--- a/pypyodbc.py
+++ b/pypyodbc.py
@@ -513,8 +513,8 @@ def UTF16_dec(buffer):
         #else:
         #    to_decode = raw[:last_match + 1]
 
-    elif "\x00" == raw[l - 1] and "\x00" == raw[l - 2]:
-        to_decode = raw[:l - 2]
+    #elif "\x00" == raw[l - 1] and "\x00" == raw[l - 2]:
+    #    to_decode = raw[:l - 2]
 
     else:
         to_decode = raw

--- a/pypyodbc.py
+++ b/pypyodbc.py
@@ -502,7 +502,7 @@ def UTF16_dec(buffer):
     #    last_match = raw.find("\x00\x00", last_match + 2)
     last_match = raw.find("\x00\x00")
     while last_match != -1 and last_match % 2 != 0:
-        last_match = raw.find("\x00\x00", last_match + 2)
+        last_match = raw.find("\x00\x00", last_match + 1)
 
     l = len(raw)
     if last_match != -1:

--- a/pypyodbc.py
+++ b/pypyodbc.py
@@ -493,8 +493,7 @@ def UCS_dec(buffer):
 def UTF16_dec(buffer):
     raw = buffer.raw
     print("Raw Buffer: %s" % raw)
-
-
+    
     if raw.startswith("\x00\x00"):
         return ""
 

--- a/pypyodbc.py
+++ b/pypyodbc.py
@@ -497,10 +497,13 @@ def UTF16_dec(buffer):
     if raw.startswith("\x00\x00"):
         return ""
     
-    last_match = raw.find("\x00\x00\x00")
+    #last_match = raw.find("\x00\x00\x00")
     #while last_match != -1 and last_match % 2 != 0:
     #    last_match = raw.find("\x00\x00", last_match + 2)
-        
+    last_match = raw.find("\x00\x00")
+    while last_match != -1 and last_match % 2 != 0:
+        last_match = raw.find("\x00\x00", last_match + 2)
+
     l = len(raw)
     if last_match != -1:
         if last_match % 2 == 0:

--- a/pypyodbc.py
+++ b/pypyodbc.py
@@ -493,14 +493,14 @@ def UCS_dec(buffer):
 def UTF16_dec(buffer):
     raw = buffer.raw
     print("Raw Buffer: %s" % raw)
-    
+
     if raw.startswith("\x00\x00"):
         return ""
-
+    
     last_match = raw.find("\x00\x00")
     while last_match != -1 and last_match % 2 != 0:
         last_match = raw.find("\x00\x00", last_match + 2)
-
+        
     l = len(raw)
     if last_match != -1:
         if last_match % 2 == 0:

--- a/pypyodbc.py
+++ b/pypyodbc.py
@@ -518,7 +518,7 @@ def UTF16_dec(buffer):
     else:
         if debug_flag:
             print("SHANI IS RIGHT")
-    to_decode = raw
+        to_decode = raw
 
     try:
         ret = to_decode.decode(odbc_decoding)

--- a/pypyodbc.py
+++ b/pypyodbc.py
@@ -506,11 +506,12 @@ def UTF16_dec(buffer):
 
     l = len(raw)
     if last_match != -1:
-        #if last_match % 2 == 0:
         to_decode = raw[:last_match]
 
-    #    else:
-    #        to_decode = raw[:last_match + 1]
+        #if last_match % 2 == 0:
+#
+        #else:
+        #    to_decode = raw[:last_match + 1]
 
     elif "\x00" == raw[l - 1] and "\x00" == raw[l - 2]:
         to_decode = raw[:l - 2]

--- a/pypyodbc.py
+++ b/pypyodbc.py
@@ -492,35 +492,19 @@ def UCS_dec(buffer):
 
 def UTF16_dec(buffer):
     raw = buffer.raw
-    print("Raw Buffer: %s" % raw)
 
     if raw.startswith("\x00\x00"):
         return ""
     
-    #last_match = raw.find("\x00\x00\x00")
-    #while last_match != -1 and last_match % 2 != 0:
-    #    last_match = raw.find("\x00\x00", last_match + 2)
+    # Seek for two consecutive null-bytes starting in an even position 
     last_match = raw.find("\x00\x00")
     while last_match != -1 and last_match % 2 != 0:
         last_match = raw.find("\x00\x00", last_match + 1)
 
-    l = len(raw)
     if last_match != -1:
         to_decode = raw[:last_match]
-
-        #if last_match % 2 == 0:
-#
-        #else:
-        #    to_decode = raw[:last_match + 1]
-
-    #elif "\x00" == raw[l - 1] and "\x00" == raw[l - 2]:
-    #    to_decode = raw[:l - 2]
-
     else:
         to_decode = raw
-
-    if 'MarshallPlan' in to_decode.decode(odbc_decoding):
-        import ipdb; ipdb.set_trace()
 
     try:
         ret = to_decode.decode(odbc_decoding)

--- a/pypyodbc.py
+++ b/pypyodbc.py
@@ -499,7 +499,7 @@ def UTF16_dec(buffer):
         return ""
 
     last_match = raw.find("\x00\x00")
-    while last_match != -1 && last_match % 2 != 0:
+    while last_match != -1 and last_match % 2 != 0:
         last_match = raw.find("\x00\x00", last_match + 2)
 
     l = len(raw)

--- a/pypyodbc.py
+++ b/pypyodbc.py
@@ -494,9 +494,14 @@ def UTF16_dec(buffer):
     raw = buffer.raw
     print("Raw Buffer: %s" % raw)
 
+
     if raw.startswith("\x00\x00"):
         return ""
-    last_match = raw.find("\x00\x00\x00")
+
+    last_match = raw.find("\x00\x00")
+    while last_match != -1 && last_match % 2 != 0:
+        last_match = raw.find("\x00\x00", last_match + 2)
+
     l = len(raw)
     if last_match != -1:
         if last_match % 2 == 0:

--- a/pypyodbc.py
+++ b/pypyodbc.py
@@ -519,7 +519,7 @@ def UTF16_dec(buffer):
     else:
         to_decode = raw
 
-    if 'MarshallPlan' in to_decode:
+    if 'MarshallPlan' in to_decode.decode(odbc_decoding):
         import ipdb; ipdb.set_trace()
         
     try:


### PR DESCRIPTION
Previously it was assumed that the buffer is always clean, so finding 3 null bytes indicates a string termination. In this [ticket](https://alooma.zendesk.com/agent/tickets/9485) we realized the buffer isn't always clean, so we must look for 2 null bytes starting on even positions.